### PR TITLE
Fix(navigation): navigate back function functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
 - 📝 **Comprehensive Logging** for debugging
 - 🧩 **Modular Architecture** for easy integration and customization
 
+## Demo App
+
+A demo app is available in the [PKSNavigationDemo](https://github.com/ohk/PKSNavigationDemo) repository. Please check it out for more examples and usage scenarios. 
+
+> AppleStoreDemo is a mock Apple Store application designed to demonstrate the integration and capabilities of the PKSNavigation framework
+
 ## Installation
 
 ### Swift Package Manager

--- a/Sources/PKSNavigation/PKSNavigation.swift
+++ b/Sources/PKSNavigation/PKSNavigation.swift
@@ -201,11 +201,13 @@ open class PKSNavigationManager: ObservableObject {
                 }
                 
             case .cover:
-                coverPath.removeLastIfAvailable()
                 if coverPath.isEmpty {
                     rootCover = nil
+                    logger.debug("Root cover removed.")
+                } else {
+                    coverPath.removeLastIfAvailable()
+                    logger.debug("Removed last item from coverPath. New cover depth: \(self.coverPath.count).")
                 }
-                logger.debug("Removed last item from coverPath. New cover depth: \(self.coverPath.count).")
             }
             updateActivePresentation()
             logger.debug(

--- a/Sources/PKSNavigation/PKSNavigation.swift
+++ b/Sources/PKSNavigation/PKSNavigation.swift
@@ -192,11 +192,14 @@ open class PKSNavigationManager: ObservableObject {
                 rootPath.removeLastIfAvailable()
                 logger.debug("Removed last item from rootPath. New stack depth: \(self.rootPath.count).")
             case .sheet:
-                sheetPath.removeLastIfAvailable()
-                if sheetPath.isEmpty {
+                if sheetPath.isEmpty { 
                     rootSheet = nil
+                    logger.debug("Root sheet removed.")
+                } else {
+                    sheetPath.removeLastIfAvailable()
+                    logger.debug("Removed last item from sheetPath. New sheet depth: \(self.sheetPath.count).")
                 }
-                logger.debug("Removed last item from sheetPath. New sheet depth: \(self.sheetPath.count).")
+                
             case .cover:
                 coverPath.removeLastIfAvailable()
                 if coverPath.isEmpty {


### PR DESCRIPTION
This pull request includes updates to the documentation and improvements to the logging in the `PKSNavigationManager` class. The most important changes are the addition of a demo app section to the README and enhanced logging when navigating back in the `PKSNavigationManager`.

Documentation updates:

* Added a "Demo App" section to the `README.md` file, which includes a link to the `PKSNavigationDemo` repository and a description of the AppleStoreDemo mock application.

Logging improvements:

* Enhanced logging in the `PKSNavigationManager` class to provide more detailed information when items are removed from `sheetPath` and `coverPath`. This includes adding debug logs when the root sheet or root cover is removed. (`Sources/PKSNavigation/PKSNavigation.swift`)